### PR TITLE
Fix redefined warning.

### DIFF
--- a/n360_USB_driver/n360_usb/src/XBOXUSB8BITDO.cpp
+++ b/n360_USB_driver/n360_usb/src/XBOXUSB8BITDO.cpp
@@ -24,7 +24,7 @@ XBOXUSB8BITDO::XBOXUSB8BITDO(USB *p) :
 pUsb(p), // pointer to USB class instance - mandatory
 bAddress(0), // device address - mandatory
 bPollEnable(false) { // don't start polling before dongle is connected
-        for(uint8_t i = 0; i < XBOX_MAX_ENDPOINTS; i++) {
+        for(uint8_t i = 0; i < XBOXUSB_MAX_ENDPOINTS; i++) {
                 epInfo[i].epAddr = 0;
                 epInfo[i].maxPktSize = (i) ? 0 : 8;
                 epInfo[i].bmSndToggle = 0;

--- a/n360_USB_driver/n360_usb/src/XBOXUSB8BITDO.h
+++ b/n360_USB_driver/n360_usb/src/XBOXUSB8BITDO.h
@@ -47,7 +47,7 @@
 
 #define XBOX_REPORT_BUFFER_SIZE 14 // Size of the input report buffer
 
-#define XBOX_MAX_ENDPOINTS   3
+#define XBOXUSB_MAX_ENDPOINTS   3
 
 /** This class implements support for a Xbox wired controller via USB. */
 class XBOXUSB8BITDO : public USBDeviceConfig {
@@ -190,7 +190,7 @@ protected:
         /** Device address. */
         uint8_t bAddress;
         /** Endpoint info structure. */
-        EpInfo epInfo[XBOX_MAX_ENDPOINTS];
+        EpInfo epInfo[XBOXUSB_MAX_ENDPOINTS];
 
 private:
         /**


### PR DESCRIPTION
Compiling the n360_usb sketch gives a warning about redefined endpoints.